### PR TITLE
[update]#18 進捗確認

### DIFF
--- a/app/models/todo.rb
+++ b/app/models/todo.rb
@@ -16,6 +16,8 @@ class Todo < ApplicationRecord
 
   enum status: { '未完了': 'todo', '完了': 'done', '期限切れ': 'expired' }
 
+  after_commit :change_status
+
   def save_tag(sent_tags)
     current_tags = tags.pluck(:name)
 
@@ -38,5 +40,14 @@ class Todo < ApplicationRecord
 
   def file_length
     return errors.add(:images, 'は3ファイルまでにしてください') if images.length > 3
+  end
+
+  def change_status
+    timeout_todos = Todo.where("limit_date < ?", Date.today).where(status: 'todo')
+    timeout_todos.each do |timeout_todo|
+      timeout_todo.status = 'expired'
+      timeout_todo.save
+    end
+    puts 'chnage status!!'
   end
 end

--- a/app/models/todo.rb
+++ b/app/models/todo.rb
@@ -43,11 +43,10 @@ class Todo < ApplicationRecord
   end
 
   def change_status
-    timeout_todos = Todo.where("limit_date < ?", Date.today).where(status: 'todo')
-    timeout_todos.each do |timeout_todo|
+    timeout_todos = Todo.where("limit_date < ?", Time.current).where(status: 'todo')
+    timeout_todos.find_each do |timeout_todo|
       timeout_todo.status = 'expired'
       timeout_todo.save
     end
-    puts 'chnage status!!'
   end
 end

--- a/app/views/users/todos/_form.html.slim
+++ b/app/views/users/todos/_form.html.slim
@@ -17,10 +17,10 @@
     = f.label :終了期日
     = f.date_field :limit_date
     = f.label :ステータス
-    - if @todo.user
-      = f.select :status, ([["完了","done"]])
-    - else
-      = f.select :status, options_for_select([["未完了","todo"], ["完了","done"]])
+    / - if @todo.user
+    /   = f.select :status, ([["完了","done"]])
+    / - else
+    = f.select :status, options_for_select([["未完了","todo"], ["完了","done"]])
     - @todo.errors.full_messages_for(:status).each do |message|
     = f.label :images
     = f.file_field :images, multiple: true

--- a/spec/factories/todos.rb
+++ b/spec/factories/todos.rb
@@ -2,7 +2,8 @@ FactoryBot.define do
   factory :todo do
     title { "MyString" }
     text { "MyText" }
-    limit_date {"Sun, 05 Jun 2022"}
+    limit_date {Time.current}
+    # "Sun, 05 Jun 2022"
     status {"todo"}
     user
     # association :user

--- a/spec/factories/todos.rb
+++ b/spec/factories/todos.rb
@@ -2,8 +2,8 @@ FactoryBot.define do
   factory :todo do
     title { "MyString" }
     text { "MyText" }
-    # limit_date {Sun, 05 Jun 2022}
-    status {'todo'}
+    limit_date {"Sun, 05 Jun 2022"}
+    status {"todo"}
     user
     # association :user
     # user_id {FactoryBot.create(:user)}
@@ -11,6 +11,8 @@ FactoryBot.define do
     # after(:build) do |post|
     #   post.image.attach(io: File.open('spec/fixtures/files/image/test_image.png'), filename: 'test_image.png', content_type: 'image/png')
     # end
+    before(:create) { Todo.skip_callback(:commit, :after, :change_status) }
+    after(:create) { Todo.set_callback(:commit, :after, :change_status) }
 
     trait :with_attachment do
       attachment { Rack::Test::UploadedFile.new(

--- a/spec/models/todo_spec.rb
+++ b/spec/models/todo_spec.rb
@@ -135,4 +135,45 @@ RSpec.describe Todo, type: :model do
       end
     end
   end
+
+  describe 'change_statusメソッド' do
+    let!(:todo) { create(:todo)}
+
+    context 'after_commitが実行される' do
+      # context '登録が失敗する場合' do
+      #   it '無効な値だと登録されないこと' do
+      #     expect {
+      #       post users_todos_path, params:{todo: {title: '',
+      #                                     text: '',
+      #                                     user_id: '',
+      #                                     name: ''}}
+      #       }.to_not change(Todo, :count)
+      #   end
+      # end
+      # context '登録が成功する場合' do
+      #   let(:todo_params) { { todo: { title: 'test',
+      #                               text: 'hogehogehoge',
+      #                               user_id: 1,
+      #                               name: tag.name} } }
+      #     it '登録されること' do
+      #     expect{
+      #       post users_todos_path, params: todo_params
+      #     }.to change(Todo, :count).by 1
+      #     end
+
+      #     it "ユーザー詳細ページにリダイレクトされること" do
+      #       post users_todos_path(todo_params)
+      #       expect(response).to redirect_to users_mypage_path
+      #       expect(flash[:success]).to be_truthy
+      #     end
+
+          it '今日より以前かつステータスが未完了がないこと' do
+              expect{todo.change_status}.to
+          end
+
+          it '取得した分だけ未完了のステータスが減ること' do
+          end
+      end
+    end
+  end
 end

--- a/spec/models/todo_spec.rb
+++ b/spec/models/todo_spec.rb
@@ -137,42 +137,20 @@ RSpec.describe Todo, type: :model do
   end
 
   describe 'change_statusメソッド' do
-    let!(:todo) { create(:todo)}
-
+    let!(:user) { create(:user) }
+    context 'after_commitの前の状態' do
+      let!(:todo) { create(:todo, limit_date: Time.current.yesterday)}
+      it '今日より以前であること' do
+          expect(todo.limit_date < Time.current).to be_truthy
+      end
+      it 'ステータスが未完了であること' do
+          expect(todo.status).to eq '未完了'
+      end
+    end
     context 'after_commitが実行される' do
-      # context '登録が失敗する場合' do
-      #   it '無効な値だと登録されないこと' do
-      #     expect {
-      #       post users_todos_path, params:{todo: {title: '',
-      #                                     text: '',
-      #                                     user_id: '',
-      #                                     name: ''}}
-      #       }.to_not change(Todo, :count)
-      #   end
-      # end
-      # context '登録が成功する場合' do
-      #   let(:todo_params) { { todo: { title: 'test',
-      #                               text: 'hogehogehoge',
-      #                               user_id: 1,
-      #                               name: tag.name} } }
-      #     it '登録されること' do
-      #     expect{
-      #       post users_todos_path, params: todo_params
-      #     }.to change(Todo, :count).by 1
-      #     end
-
-      #     it "ユーザー詳細ページにリダイレクトされること" do
-      #       post users_todos_path(todo_params)
-      #       expect(response).to redirect_to users_mypage_path
-      #       expect(flash[:success]).to be_truthy
-      #     end
-
-          it '今日より以前かつステータスが未完了がないこと' do
-              expect{todo.change_status}.to
-          end
-
-          it '取得した分だけ未完了のステータスが減ること' do
-          end
+      let!(:todo) { create(:todo, limit_date: Time.current.yesterday)}
+      it '未完了から期限切れになること' do
+        expect{todo.send(:change_status)}.to change{ todo.reload.status }.from('未完了').to('期限切れ')
       end
     end
   end

--- a/spec/models/todo_spec.rb
+++ b/spec/models/todo_spec.rb
@@ -138,15 +138,6 @@ RSpec.describe Todo, type: :model do
 
   describe 'change_statusメソッド' do
     let!(:user) { create(:user) }
-    context 'after_commitの前の状態' do
-      let!(:todo) { create(:todo, limit_date: Time.current.yesterday)}
-      it '今日より以前であること' do
-          expect(todo.limit_date < Time.current).to be_truthy
-      end
-      it 'ステータスが未完了であること' do
-          expect(todo.status).to eq '未完了'
-      end
-    end
     context 'after_commitが実行される' do
       let!(:todo) { create(:todo, limit_date: Time.current.yesterday)}
       it '未完了から期限切れになること' do


### PR DESCRIPTION
# Why
期限が過ぎた未完了のtodoのステータスをexpriedにするため

# What
コールバック関数を用いて、ユーザーがサービスを使用したら（commit）したら期限が過ぎた未完了のtodoのステータスをexpriedにする。
登録、更新、削除されたら
after_commitを実行する

# その他
after_findで実装したらかなり速度が遅く なってしまったので、一旦after_commitにしました。
