### PR TITLE
Feature/19 期限切れTodoのステータスを期限切れに変更

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+WEBHOOK_URL='https://hooks.slack.com/services/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'

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@
 
 # Ignore master key for decrypting credentials and more.
 /config/master.key
+.env

--- a/app/models/todo.rb
+++ b/app/models/todo.rb
@@ -16,7 +16,6 @@ class Todo < ApplicationRecord
 
   enum status: { '未完了': 'todo', '完了': 'done', '期限切れ': 'expired' }
 
-  after_commit :change_status
 
   def save_tag(sent_tags)
     current_tags = tags.pluck(:name)
@@ -42,11 +41,11 @@ class Todo < ApplicationRecord
     return errors.add(:images, 'は3ファイルまでにしてください') if images.length > 3
   end
 
-  def change_status
-    timeout_todos = Todo.where("limit_date < ?", Time.current).where(status: 'todo')
-    timeout_todos.find_each do |timeout_todo|
-      timeout_todo.status = 'expired'
-      timeout_todo.save
-    end
-  end
+  # def change_status
+  #   timeout_todos = Todo.where("limit_date < ?", Time.current).where(status: 'todo')
+  #   timeout_todos.find_each do |timeout_todo|
+  #     timeout_todo.status = 'expired'
+  #     timeout_todo.save
+  #   end
+  # end
 end

--- a/app/models/todo.rb
+++ b/app/models/todo.rb
@@ -16,7 +16,6 @@ class Todo < ApplicationRecord
 
   enum status: { '未完了': 'todo', '完了': 'done', '期限切れ': 'expired' }
 
-
   def save_tag(sent_tags)
     current_tags = tags.pluck(:name)
 
@@ -32,6 +31,14 @@ class Todo < ApplicationRecord
     new_tags.each do |new_tag|
       new_todo_tag = Tag.find_or_create_by(name: new_tag, user_id:)
       tags << new_todo_tag
+    end
+  end
+
+  def self.change_status
+    timeout_todos = Todo.where("limit_date < ?", Time.current).where(status: 'todo')
+    timeout_todos.find_each do |timeout_todo|
+      timeout_todo.status = 'expired'
+      timeout_todo.save
     end
   end
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,6 @@ services:
     ports:
       - "5432:5432"
     environment:
-      TZ: Asia/Tokyo
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: password
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
     ports:
       - "5432:5432"
     environment:
+      TZ: Asia/Tokyo
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: password
 
@@ -23,6 +24,7 @@ services:
     tty: true
     stdin_open: true
     environment:
+      TZ: Asia/Tokyo
       APP_DATABASE_HOST: db
       APP_DATABASE_USERNAME: postgres
       APP_DATABASE_PASSWORD: password

--- a/lib/tasks/change_status.rake
+++ b/lib/tasks/change_status.rake
@@ -1,10 +1,6 @@
 namespace :change_status do
   desc '期限切れのTodoステータスをexpiredに変更'
   task change_expired: :environment do
-    timeout_todos = Todo.where("limit_date < ?", Time.current).where(status: 'todo')
-    timeout_todos.find_each do |timeout_todo|
-      timeout_todo.status = 'expired'
-      timeout_todo.save
-    end
+    Todo.change_status
   end
 end

--- a/lib/tasks/change_status.rake
+++ b/lib/tasks/change_status.rake
@@ -1,0 +1,10 @@
+namespace :change_status do
+  desc '期限切れのTodoステータスをexpiredに変更'
+  task change_expired: :environment do
+    timeout_todos = Todo.where("limit_date < ?", Time.current).where(status: 'todo')
+    timeout_todos.find_each do |timeout_todo|
+      timeout_todo.status = 'expired'
+      timeout_todo.save
+    end
+  end
+end

--- a/spec/factories/todos.rb
+++ b/spec/factories/todos.rb
@@ -12,8 +12,6 @@ FactoryBot.define do
     # after(:build) do |post|
     #   post.image.attach(io: File.open('spec/fixtures/files/image/test_image.png'), filename: 'test_image.png', content_type: 'image/png')
     # end
-    before(:create) { Todo.skip_callback(:commit, :after, :change_status) }
-    after(:create) { Todo.set_callback(:commit, :after, :change_status) }
 
     trait :with_attachment do
       attachment { Rack::Test::UploadedFile.new(

--- a/spec/lib/tasks/change_status.rb
+++ b/spec/lib/tasks/change_status.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+require 'rake'
+
+describe 'change_status' do
+  before(:all) do
+    @rake = Rake::Application.new
+    Rake.application = @rake
+    Rake.application.rake_require 'tasks/change_status'
+    Rake::Task.define_task(:environment)
+  end
+
+  # spec内で同一タスクを2回以上実行しないのであれば不要
+  # before(:each) do
+  #   @rake[task].reenable
+  # end
+
+  describe 'change_expired' do
+    let(:task) { 'change_status:change_expired' }
+
+    it 'is success' do
+      expect(@rake[task].invoke).to be_truthy
+    end
+  end
+end

--- a/spec/lib/tasks/change_status.rb
+++ b/spec/lib/tasks/change_status.rb
@@ -5,6 +5,7 @@ describe 'change_status' do
   before(:all) do
     @rake = Rake::Application.new
     Rake.application = @rake
+    # Rake.application.rake_require('change_expired', [Rails.root.join('lib', 'tasks', 'change_status')])
     Rake.application.rake_require 'tasks/change_status'
     Rake::Task.define_task(:environment)
   end

--- a/spec/models/todo_spec.rb
+++ b/spec/models/todo_spec.rb
@@ -135,4 +135,14 @@ RSpec.describe Todo, type: :model do
       end
     end
   end
+
+  describe 'change_statusメソッド' do
+    let!(:user) { create(:user) }
+    context 'after_commitが実行される' do
+      let!(:todo) { create(:todo, limit_date: Time.current.yesterday)}
+      it '未完了から期限切れになること' do
+        expect{Todo.change_status}.to change{ todo.reload.status }.from('未完了').to('期限切れ')
+      end
+    end
+  end
 end

--- a/spec/models/todo_spec.rb
+++ b/spec/models/todo_spec.rb
@@ -135,14 +135,4 @@ RSpec.describe Todo, type: :model do
       end
     end
   end
-
-  describe 'change_statusメソッド' do
-    let!(:user) { create(:user) }
-    context 'after_commitが実行される' do
-      let!(:todo) { create(:todo, limit_date: Time.current.yesterday)}
-      it '未完了から期限切れになること' do
-        expect{todo.send(:change_status)}.to change{ todo.reload.status }.from('未完了').to('期限切れ')
-      end
-    end
-  end
 end


### PR DESCRIPTION
# Why
バッチ処理で
期限が過ぎた未完了のtodoのステータスをexpriedにするため

# What
rake タスクを使って実装
定期実行にはHerokuのスケジューラー（時間はUTC設定しかできないようなので要確認）
毎:00に設定予定

HerokuのタイムゾーンをUTC→JSTに変更

