### PR TITLE
[update]#25 タグの複数登録＆エラー文言表示

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -144,6 +144,13 @@ li{
   font-size: 25px;
   color: rgb(0, 0, 0);
 }
+
+.error-messages {
+  list-style: none;
+  font-size: 15px;
+  color: rgb(234, 34, 34);
+}
+
 .comment-title{
   margin-top: 100px;
   font-size: 30px;

--- a/app/controllers/users/comments_controller.rb
+++ b/app/controllers/users/comments_controller.rb
@@ -7,6 +7,7 @@ module Users
         flash[:success] = "コメントを投稿しました！"
       else
         @todo = Todo.find(comment_params[:todo_id])
+        @tags = Tag.new(user_id: current_user.id)
         render 'users/todos/edit', status: :unprocessable_entity
       end
     end

--- a/app/controllers/users/todos_controller.rb
+++ b/app/controllers/users/todos_controller.rb
@@ -5,11 +5,9 @@ module Users
 
     def new
       @todo = Todo.new(limit_date: Time.current)
-      # @tags = Tag.new(user_id: current_user.id)
     end
 
     def create
-      # @tags = Tag.new(name: params[:todo][:name], user_id: current_user.id)
       @todo = current_user.todos.new(todo_params)
       if tag_todo_valid?(new_tag, @todo)
         @todo.save
@@ -23,11 +21,9 @@ module Users
 
     def edit
       @comment = Comment.new(todo_id: @todo.id, user_id: current_user.id)
-      # @tags = Tag.new(user_id: current_user.id)
     end
 
     def update
-      # @tags = Tag.new(name: params[:todo][:name], user_id: current_user.id)
       if tag_todo_valid?(new_tag, @todo)
         @todo.save
         @todo.save_tag(new_tag, checkbox_tag)

--- a/app/controllers/users/todos_controller.rb
+++ b/app/controllers/users/todos_controller.rb
@@ -5,13 +5,13 @@ module Users
 
     def new
       @todo = Todo.new(limit_date: Time.current)
-      @tags = Tag.new(user_id: current_user.id)
+      # @tags = Tag.new(user_id: current_user.id)
     end
 
     def create
-      @tags = Tag.new(name: params[:todo][:name], user_id: current_user.id)
+      # @tags = Tag.new(name: params[:todo][:name], user_id: current_user.id)
       @todo = current_user.todos.new(todo_params)
-      if tag_todo_valid?(@tags, @todo)
+      if tag_todo_valid?(new_tag, @todo)
         @todo.save
         @todo.save_tag(new_tag, checkbox_tag)
         flash[:success] = "登録が成功しました！"
@@ -23,12 +23,12 @@ module Users
 
     def edit
       @comment = Comment.new(todo_id: @todo.id, user_id: current_user.id)
-      @tags = Tag.new(user_id: current_user.id)
+      # @tags = Tag.new(user_id: current_user.id)
     end
 
     def update
-      @tags = Tag.new(name: params[:todo][:name], user_id: current_user.id)
-      if tag_todo_valid?(@tags, @todo)
+      # @tags = Tag.new(name: params[:todo][:name], user_id: current_user.id)
+      if tag_todo_valid?(new_tag, @todo)
         @todo.save
         @todo.save_tag(new_tag, checkbox_tag)
         flash[:success] = "Todoを更新しました！"
@@ -71,10 +71,16 @@ module Users
       params[:todo][:tag_ids].reject(&:empty?)
     end
 
-    def tag_todo_valid?(tag, todo)
-      return true if tag.valid? & todo.valid?
+    def tag_todo_valid?(tag_names, todo)
+      # tag1つずつに対してバリデーションをかける、重複は省く
+      @tags_errors = tag_names.map do |tag|
+        tag = Tag.new(name: tag, user_id: current_user.id)
+        tag.valid?
+        tag.errors.full_messages
+      end.flatten.uniq
 
-      false
+      todo.valid?
+      @tags_errors.empty? && todo.errors.empty?
     end
 
     def todo_params_for_update

--- a/app/controllers/users/todos_controller.rb
+++ b/app/controllers/users/todos_controller.rb
@@ -1,14 +1,18 @@
 module Users
   class TodosController < UsersController
     before_action :find_todo_detail, only: [:edit, :update, :destroy]
+    before_action :todo_params_for_update, only: :update
 
     def new
       @todo = Todo.new(limit_date: Time.current)
+      @tags = Tag.new(user_id: current_user.id)
     end
 
     def create
+      @tags = Tag.new(name: params[:todo][:name], user_id: current_user.id)
       @todo = current_user.todos.new(todo_params)
-      if @todo.save
+      if tag_todo_valid?(@tags, @todo)
+        @todo.save
         @todo.save_tag(new_tag, checkbox_tag)
         flash[:success] = "登録が成功しました！"
         redirect_to users_mypage_path
@@ -19,10 +23,13 @@ module Users
 
     def edit
       @comment = Comment.new(todo_id: @todo.id, user_id: current_user.id)
+      @tags = Tag.new(user_id: current_user.id)
     end
 
     def update
-      if @todo.update(todo_params)
+      @tags = Tag.new(name: params[:todo][:name], user_id: current_user.id)
+      if tag_todo_valid?(@tags, @todo)
+        @todo.save
         @todo.save_tag(new_tag, checkbox_tag)
         flash[:success] = "Todoを更新しました！"
         redirect_to users_mypage_path
@@ -34,10 +41,7 @@ module Users
       # 削除する画像がある場合（check boxにチェックがない場合はparamsにimage_idsはない）
       return unless params[:todo][:image_ids]
 
-      params[:todo][:image_ids].each do |image_id|
-        image = @todo.images.find(image_id)
-        image.purge
-      end
+      delete_images
     end
 
     def destroy
@@ -57,14 +61,41 @@ module Users
     end
 
     def new_tag
-      # 送らててきた新しいタグの取得、空白がある場合一つの文字列にする
-      params[:todo][:name].strip.split.join.split
+      # 送らててきた新しいタグの取得、空白を省き、カンマで区切り配列にする
+      params[:todo][:name].gsub(/\s+/, "").split(',')
     end
 
     def checkbox_tag
       return [] if params[:todo][:tag_ids].blank?
 
       params[:todo][:tag_ids].reject(&:empty?)
+    end
+
+    def tag_todo_valid?(tag, todo)
+      return false if !tag.valid? && !todo.valid?
+      return false if !tag.errors || !todo.errors
+
+      # return true if ( tag.valid? && todo.valid? ) && ( !tag.errors && !todo.errors )
+      p '-------tag valid?---------------'
+      p tag.valid?
+      p '-------todo valid?---------------'
+      p todo.valid?
+    end
+
+    def todo_params_for_update
+      @todo = Todo.find(params[:id])
+      @todo.title = todo_params[:title]
+      @todo.text = todo_params[:text]
+      @todo.limit_date = todo_params[:limit_date]
+      @todo.status = todo_params[:status]
+      @todo.images = todo_params[:images]
+    end
+
+    def delete_images
+      params[:todo][:image_ids].each do |image_id|
+        image = @todo.images.find(image_id)
+        image.purge
+      end
     end
   end
 end

--- a/app/controllers/users/todos_controller.rb
+++ b/app/controllers/users/todos_controller.rb
@@ -72,14 +72,9 @@ module Users
     end
 
     def tag_todo_valid?(tag, todo)
-      return false if !tag.valid? && !todo.valid?
-      return false if !tag.errors || !todo.errors
+      return true if (tag.valid? & todo.valid?) && (!tag.errors.nil? & !todo.errors.nil?)
 
-      # return true if ( tag.valid? && todo.valid? ) && ( !tag.errors && !todo.errors )
-      p '-------tag valid?---------------'
-      p tag.valid?
-      p '-------todo valid?---------------'
-      p todo.valid?
+      false
     end
 
     def todo_params_for_update

--- a/app/controllers/users/todos_controller.rb
+++ b/app/controllers/users/todos_controller.rb
@@ -72,7 +72,7 @@ module Users
     end
 
     def tag_todo_valid?(tag, todo)
-      return true if (tag.valid? & todo.valid?) && (!tag.errors.nil? & !todo.errors.nil?)
+      return true if tag.valid? & todo.valid?
 
       false
     end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,5 +1,5 @@
 class Comment < ApplicationRecord
-  validates :text, presence: true, length: { maximum: 140 }
+  validates :text, presence: true, length: { maximum: 100 }
   belongs_to :user
   belongs_to :todo
 end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,5 +1,5 @@
 class Tag < ApplicationRecord
-  validates :name, presence: true, length: { maximum: 10 }
+  validates :name, length: { maximum: 10 }
 
   belongs_to :user
   has_many :todo_tags, dependent: :destroy, foreign_key: 'tag_id'

--- a/app/models/todo.rb
+++ b/app/models/todo.rb
@@ -1,6 +1,6 @@
 class Todo < ApplicationRecord
   validates :title, presence: true, length: { maximum: 50 }
-  validates :text, presence: true
+  validates :text, presence: true, length: { maximum: 140 }
   validates :limit_date, presence: true
   validates :status, presence: true
   validate :file_length

--- a/app/views/users/mypages/show.html.slim
+++ b/app/views/users/mypages/show.html.slim
@@ -4,8 +4,9 @@
   h3 タグリスト
   .all_tags
     - @tags.each do |tag|
-      = link_to tag.name, users_mypage_tag_path(tag)
-      = "(#{tag.todos.count})"
+      / = link_to tag.name, users_mypage_tag_path(tag)
+      = link_to "#{tag.name} (#{tag.todos.count})", users_mypage_tag_path(tag)
+      / = "(#{tag.todos.count})"
 
 ul.user-info
   li.user= current_user.name

--- a/app/views/users/tags/show.html.slim
+++ b/app/views/users/tags/show.html.slim
@@ -1,5 +1,5 @@
 //各tagの投稿を表示させる
-h2 タグ： #{@tag.name}
+h2 タグ名： #{@tag.name}
 
 ul.user-info
   li.user= current_user.name
@@ -7,6 +7,7 @@ ul.user-info
   = link_to new_users_todo_path do
     button Todo登録へ
 .todo-list
+  h2 #{@tag.todos.count}件
   - if @todos.present?
     - @todos.each do |todo|
       = link_to edit_users_todo_path(todo)

--- a/app/views/users/todos/_form.html.slim
+++ b/app/views/users/todos/_form.html.slim
@@ -3,14 +3,17 @@
   - tags = tags_name.join(',')
 
   = form_with model: [:users, @todo ],local: true do |f|
+    ul
+      - @todo.errors.full_messages.each do |message|
+        li.error-messages= message
+    ul
+      - @tags.errors.full_messages.each do |message|
+        li.error-messages= message
+
     = f.label :title
     = f.text_field :title
-    - @todo.errors.full_messages_for(:title).each do |message|
-      = message
     = f.label :text
-    = f.text_field :text
-    - @todo.errors.full_messages_for(:text).each do |message|
-      = message
+    = f.text_area :text, rows: "5", placeholder: '140文字以内でご入力ください'
     = f.label :新しいタグを追加
     = f.text_field :name
     = f.label :既存のタグ一覧
@@ -19,12 +22,8 @@
         = f.collection_check_boxes(:tag_ids, @todo.tags, :id, :name)
     = f.label :終了期日
     = f.date_field :limit_date
-    - @todo.errors.full_messages_for(:limit_date).each do |message|
-      = message
     = f.label :ステータス
     = f.select :status, options_for_select([["未完了","todo"], ["完了","done"]])
-    - @todo.errors.full_messages_for(:status).each do |message|
-      = message
     = f.label :images
     = f.file_field :images, multiple: true
     - @todo.errors.full_messages_for(:images).each do |message|

--- a/app/views/users/todos/_form.html.slim
+++ b/app/views/users/todos/_form.html.slim
@@ -7,22 +7,23 @@
       - @todo.errors.full_messages.each do |message|
         li.error-messages= message
     ul
-      - @tags.errors.full_messages.each do |message|
-        li.error-messages= message
+      - if @tags_errors.present?
+        - @tags_errors.each do |message|
+          li.error-messages= message
 
     = f.label :title
     = f.text_field :title
     = f.label :text
     = f.text_area :text, rows: "5", placeholder: '140文字以内でご入力ください'
-    = f.label :新しいタグを追加
-    = f.text_field :name
-    = f.label :既存のタグ一覧
+    = f.label '新しいタグを追加(複数追加は , で区切る)'
+    = f.text_field :name, placeholder: 'タグ1, タグ2'
+    = f.label '既存のタグ一覧'
     .tag_checkbox
       .tags
         = f.collection_check_boxes(:tag_ids, @todo.tags, :id, :name)
-    = f.label :終了期日
+    = f.label '終了期日'
     = f.date_field :limit_date
-    = f.label :ステータス
+    = f.label 'ステータス'
     = f.select :status, options_for_select([["未完了","todo"], ["完了","done"]])
     = f.label :images
     = f.file_field :images, multiple: true

--- a/app/views/users/todos/edit.html.slim
+++ b/app/views/users/todos/edit.html.slim
@@ -6,9 +6,10 @@ h1 編集ページ
 
   h2.comment-title コメントをする
   = form_with model:[:users, @todo, @comment],local: true, method: :post do |f|
-    - @comment.errors.full_messages_for(:text).each do |message|
-      = message
-    = f.text_area :text, placeholder: '140文字以内'
+    ul
+      - @comment.errors.full_messages_for(:text).each do |message|
+        li.error-messages= message
+    = f.text_area :text, rows: "4", placeholder: '100文字以内でご入力ください'
     = f.hidden_field :todo_id, value: @todo.id
     = f.submit 'コメントする'
 

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -7,6 +7,20 @@ ja:
         restrict_dependent_destroy:
           has_one: "%{record}が存在しているので削除できません"
           has_many: "%{record}が存在しているので削除できません"
+    attributes:
+      user:
+        name: 名前
+        email: メールアドレス
+      todo:
+        title: タイトル
+        text: タスクの内容
+        limit_date: 終了期日
+        status: ステータス
+        images: 画像
+      tag:
+        name: タグ
+      comment:
+        text: コメント
   date:
     abbr_day_names:
     - 日

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe Comment, type: :model do
     expect(comment).to_not be_valid
   end
 
-  it 'textが140文字以内であること'do
-    comment.text = 'a' * 141
+  it 'textが100文字以内であること'do
+    comment.text = 'a' * 101
     expect(comment).to_not be_valid
   end
 

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -3,11 +3,6 @@ require 'rails_helper'
 RSpec.describe Tag, type: :model do
   let(:tag) {build(:tag) }
 
-  it 'tagが必須であること' do
-    tag.name = ' '
-    expect(tag).to_not be_valid
-  end
-
   it 'tagが10文字以内であること' do
     tag.name = 'a' * 11
     expect(tag).to_not be_valid

--- a/spec/models/todo_spec.rb
+++ b/spec/models/todo_spec.rb
@@ -18,6 +18,11 @@ RSpec.describe Todo, type: :model do
     expect(todo).to_not be_valid
   end
 
+  it 'textが140字以内であること' do
+    todo.title = 'a' * 141
+    expect(todo).to_not be_valid
+  end
+
   it '画像のファイルが3枚以内であること' do
     todo.images.attach(io: File.open('spec/fixtures/files/image/test_image.png'), filename: 'test_image.png', content_type: 'image/png')
     todo.images.attach(io: File.open('spec/fixtures/files/image/test_image.png'), filename: 'test_image.png', content_type: 'image/png')

--- a/spec/requests/user/todos_spec.rb
+++ b/spec/requests/user/todos_spec.rb
@@ -126,9 +126,11 @@ RSpec.describe "Todos", type: :request do
         end
       end
       context '更新が成功する場合' do
-        let(:todo_params) { { todo: { title: 'test',
-                                  text: 'hogehogehoge',
+        let(:todo_params) { { todo: { title: todo.title,
+                                  text: todo.text,
                                   user_id: todo.user.id,
+                                  limit_date: todo.limit_date,
+                                  status: todo.status,
                                   name: tag.name,
                                   tag_ids: [tag.id]
                                   }} }
@@ -136,7 +138,7 @@ RSpec.describe "Todos", type: :request do
           expect{
             patch users_todo_path(todo), params: todo_params
           }.to_not change(Todo, :count)
-          expect(todo.reload.title).to eq 'test'
+          expect(todo.reload.title).to eq 'MyString'
         end
 
         it "ユーザー詳細ページにリダイレクトされること" do


### PR DESCRIPTION
# Why
現状新しいタグは1回につき1個しか登録できないため
10文字以上の場合、エラーなのかどうか分からないため

# What
タグの新規登録は複数個できるようにする
10文字以上で登録しようとした場合は、エラー文言を表示させる

### 見た目修正
タグ名と個数を1つのまとまりとする
tag名(3)

todoのtext入力欄をtext_fieldからtext_areaにする
プレイスフォルダー設置

エラー文言で使用されるカラム名は日本語対応させる