### PR TITLE
[udpate]#33 バリデーションに引っかかった際に入力したタグが消えないようにする

### DIFF
--- a/app/controllers/users/todos_controller.rb
+++ b/app/controllers/users/todos_controller.rb
@@ -15,6 +15,7 @@ module Users
         flash[:success] = "登録が成功しました！"
         redirect_to users_mypage_path
       else
+        @tags = params[:todo][:name]
         render 'new', status: :unprocessable_entity
       end
     end
@@ -30,6 +31,7 @@ module Users
         flash[:success] = "Todoを更新しました！"
         redirect_to users_mypage_path
       else
+        @tags = params[:todo][:name]
         @comment = Comment.new(todo_id: @todo.id, user_id: current_user.id)
         render 'edit', status: :unprocessable_entity
       end

--- a/app/views/users/todos/_form.html.slim
+++ b/app/views/users/todos/_form.html.slim
@@ -16,7 +16,7 @@
     = f.label :text
     = f.text_area :text, rows: "5", placeholder: '140文字以内でご入力ください'
     = f.label '新しいタグを追加(複数追加は , で区切る)'
-    = f.text_field :name, placeholder: 'タグ1, タグ2'
+    = f.text_field :name, placeholder: 'タグ1, タグ2', value: @tags
     = f.label '既存のタグ一覧'
     .tag_checkbox
       .tags


### PR DESCRIPTION
# Why
バリデーションに引っかかった際に入力したタグが消えると、再度入力しないといけなく、ユーザービリティが良くない。

# What
送られてきた値をrender先にわたす