### PR TITLE
[update]#32 バッチ処理エラーの場合の対応

### DIFF
--- a/app/models/todo.rb
+++ b/app/models/todo.rb
@@ -60,6 +60,11 @@ class Todo < ApplicationRecord
     notifier.ping "明日期限の未完了Todoは#{expired_tomorrow_todos.count}件です。\n#{all_todo_title}"
   end
 
+  def self.send_error_message(message)
+    notifier = Slack::Notifier.new(ENV['WEBHOOK_URL'])
+    notifier.ping message
+  end
+
   private
 
   def file_length

--- a/lib/tasks/change_status.rake
+++ b/lib/tasks/change_status.rake
@@ -1,6 +1,21 @@
+MAX_ATTEMPTS = 3
+num_attempts = 0
+
 namespace :change_status do
   desc '期限切れのTodoステータスをexpiredに変更'
   task change_expired: :environment do
+    num_attempts += 1
     Todo.change_status
+  rescue StandardError => e
+    if num_attempts <= MAX_ATTEMPTS
+      sleep 60
+      message = p "change_expiredのエラーが発生しました!(#{num_attempts}回目目)"
+      Todo.send_error_message(message)
+      retry
+    else
+      puts e
+    end
+  ensure
+    puts 'finish!!!!!!!!!!!!!!!!!!!!!'
   end
 end

--- a/lib/tasks/todo_notifier.rake
+++ b/lib/tasks/todo_notifier.rake
@@ -1,6 +1,21 @@
+MAX_ATTEMPTS = 3
+num_attempts = 0
+
 namespace :todo_notifier do
   desc '1日後に終了期限の未完了Todoを取得して通知'
   task get_todo_status: :environment do
+    num_attempts += 1
     Todo.notice_expired_todo
+  rescue StandardError => e
+    if num_attempts <= MAX_ATTEMPTS
+      sleep 60
+      message = p "get_todo_statusのエラーが発生しました!(#{num_attempts}回目目)"
+      Todo.send_error_message(message)
+      retry
+    else
+      puts e
+    end
+  ensure
+    puts 'finish!!!!!!!!!!!!!!!!!!!!!'
   end
 end


### PR DESCRIPTION
# Why
バッチ処理
Todoのステータスを期限切れに変更
終了期日が1日前に迫ったものをスラックに通知

上記のエラー時の対応をする

# What
begin rescueで例外に対応する
60秒後にretry マックス3回

 ログ出力とスラックにエラーが発生したことを通知する