### PR TITLE
[update]#42 タグのCRUD機能の追加

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -151,6 +151,10 @@ li{
   margin-right: 10px;
 }
 
+.delete_button{
+  margin-top: 40px;
+}
+
 .user-info{
   width: 70%;
   margin: 0 auto;

--- a/app/controllers/users/tags_controller.rb
+++ b/app/controllers/users/tags_controller.rb
@@ -1,16 +1,16 @@
 module Users
   class TagsController < UsersController
     def show
-      @tag = Tag.find(params[:id]) # クリックしたタグを取得
+      @tag = current_user.tags.find(params[:id]) # クリックしたタグを取得
       @todos = @tag.todos.all.page(params[:page]).per(8)  # クリックしたタグに紐付けられた投稿を全て表示
     end
 
     def edit
-      @tag = Tag.find(params[:id])
+      @tag = current_user.tags.find(params[:id])
     end
 
     def update
-      @tag = Tag.find(params[:id])
+      @tag = current_user.tags.find(params[:id])
       if @tag.update(tag_params)
         flash[:success] = "タグを更新しました！"
         redirect_to users_mypage_path
@@ -20,7 +20,7 @@ module Users
     end
 
     def destroy
-      @tag = Tag.find(params[:id])
+      @tag = current_user.tags.find(params[:id])
       @tag.destroy
       flash[:success] = "タグを削除しました！"
       redirect_to users_mypage_path

--- a/app/controllers/users/tags_controller.rb
+++ b/app/controllers/users/tags_controller.rb
@@ -1,7 +1,7 @@
 module Users
   class TagsController < UsersController
     def show
-      @tag = current_user.tags.find(params[:id]) # クリックしたタグを取得
+      @tag = Tag.find(params[:id]) # クリックしたタグを取得
       @todos = @tag.todos.all.page(params[:page]).per(8)  # クリックしたタグに紐付けられた投稿を全て表示
     end
 

--- a/app/controllers/users/tags_controller.rb
+++ b/app/controllers/users/tags_controller.rb
@@ -1,8 +1,35 @@
 module Users
   class TagsController < UsersController
     def show
-      @tag = Tag.find(params[:id])  # クリックしたタグを取得
+      @tag = Tag.find(params[:id]) # クリックしたタグを取得
       @todos = @tag.todos.all.page(params[:page]).per(8)  # クリックしたタグに紐付けられた投稿を全て表示
+    end
+
+    def edit
+      @tag = Tag.find(params[:id])
+    end
+
+    def update
+      @tag = Tag.find(params[:id])
+      if @tag.update(tag_params)
+        flash[:success] = "タグを更新しました！"
+        redirect_to users_mypage_path
+      else
+        render 'edit', status: :unprocessable_entity
+      end
+    end
+
+    def destroy
+      @tag = Tag.find(params[:id])
+      @tag.destroy
+      flash[:success] = "タグを削除しました！"
+      redirect_to users_mypage_path
+    end
+
+    private
+
+    def tag_params
+      params.require(:tag).permit(:name).merge(user_id: current_user.id)
     end
   end
 end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,6 +1,5 @@
 class Tag < ApplicationRecord
-  validates :name, length: { maximum: 10 }
-  validates :name, presence: true, on: :update
+  validates :name, length: { maximum: 10 }, presence: true
   validate :limit_number_of_tags
 
   belongs_to :user

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,5 +1,6 @@
 class Tag < ApplicationRecord
   validates :name, length: { maximum: 10 }
+  validates :name, presence: true, on: :update
   validate :limit_number_of_tags
 
   belongs_to :user

--- a/app/views/users/mypages/show.html.slim
+++ b/app/views/users/mypages/show.html.slim
@@ -13,8 +13,7 @@
 ul.user-info
   li.user= current_user.name
   li.user= current_user.email
-  = link_to new_users_todo_path do
-    button Todo登録へ
+  = button_to 'Todo登録へ', new_users_todo_path, method: :get, class: "btn btn-success"
 br
 
 ul.user-info

--- a/app/views/users/tags/edit.html.slim
+++ b/app/views/users/tags/edit.html.slim
@@ -1,0 +1,24 @@
+//各tagの投稿を表示させる
+h1 タグ編集ページ
+
+ul.user-info
+  li.user= current_user.name
+  li.user= current_user.email
+  = link_to new_users_todo_path do
+    button Todo登録へ
+
+.col-md-4.col-md-offset-4
+  = form_with model: [:users, :mypage, @tag ],local: true do |f|
+    ul
+      - @tag.errors.full_messages.each do |message|
+        li.error-messages= message
+
+    = f.label 'タグの編集'
+    = f.text_field :name, placeholder: '10文字以内で入力してください', value: @tag.name
+    = f.submit class: "btn btn-primary"
+
+.delete_button
+  = button_to "削除する", users_mypage_tag_path(@tag), class: "btn btn-danger", method: :delete
+
+
+h2 = link_to 'マイページに戻る', users_mypage_path

--- a/app/views/users/tags/edit.html.slim
+++ b/app/views/users/tags/edit.html.slim
@@ -4,8 +4,7 @@ h1 タグ編集ページ
 ul.user-info
   li.user= current_user.name
   li.user= current_user.email
-  = link_to new_users_todo_path do
-    button Todo登録へ
+  = button_to 'Todo登録へ', new_users_todo_path, method: :get, class: "btn btn-success"
 
 .col-md-4.col-md-offset-4
   = form_with model: [:users, :mypage, @tag ],local: true do |f|

--- a/app/views/users/tags/show.html.slim
+++ b/app/views/users/tags/show.html.slim
@@ -4,6 +4,8 @@ h2 タグ名： #{@tag.name}
 ul.user-info
   li.user= current_user.name
   li.user= current_user.email
+  = link_to edit_users_mypage_tag_path do
+    button タグ編集
   = link_to new_users_todo_path do
     button Todo登録へ
 .todo-list

--- a/app/views/users/tags/show.html.slim
+++ b/app/views/users/tags/show.html.slim
@@ -4,7 +4,7 @@ h2 タグ名： #{@tag.name}
 ul.user-info
   li.user= current_user.name
   li.user= current_user.email
-  = button_to 'タグ編集', new_users_todo_path, method: :get, class: "btn btn-primary"
+  = button_to 'タグ編集', edit_users_mypage_tag_path, method: :get, class: "btn btn-primary"
   = button_to 'Todo登録へ', new_users_todo_path, method: :get, class: "btn btn-success"
 .todo-list
   h2 #{@tag.todos.count}件

--- a/app/views/users/tags/show.html.slim
+++ b/app/views/users/tags/show.html.slim
@@ -4,10 +4,8 @@ h2 タグ名： #{@tag.name}
 ul.user-info
   li.user= current_user.name
   li.user= current_user.email
-  = link_to edit_users_mypage_tag_path do
-    button タグ編集
-  = link_to new_users_todo_path do
-    button Todo登録へ
+  = button_to 'タグ編集', new_users_todo_path, method: :get, class: "btn btn-primary"
+  = button_to 'Todo登録へ', new_users_todo_path, method: :get, class: "btn btn-success"
 .todo-list
   h2 #{@tag.todos.count}件
   - if @todos.present?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,7 @@ Rails.application.routes.draw do
 
   namespace :users do
     resource :mypage, only: :show do
-      resources :tags, only: :show
+      resources :tags, only: [:show, :edit, :update, :destroy]
       get '/find_to/:status', to: 'statuses#find_status', as: 'status'
     end
     resources :todos, only:[:new, :create, :edit, :update, :destroy] do

--- a/spec/requests/user/tag_spec.rb
+++ b/spec/requests/user/tag_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "Tag", type: :request do
       end
       it "returns http success" do
         get users_mypage_tag_path(tag)
-        expect(todo.tags).to be_truthy
+        expect(response).to have_http_status(:success)
       end
     end
 

--- a/spec/requests/user/tag_spec.rb
+++ b/spec/requests/user/tag_spec.rb
@@ -24,4 +24,83 @@ RSpec.describe "Tag", type: :request do
       end
     end
   end
+
+  describe "GET users/mypage/tags/:id/edit #edit" do
+    context 'ログインしている場合' do
+      before do
+        sign_in(tag.user)
+      end
+      it "return http success" do
+        get edit_users_mypage_tag_path(tag)
+        expect(response).to have_http_status(:success)
+      end
+    end
+    context "ログインしていない場合" do
+      it "ログインページにリダイレクトされること" do
+        get edit_users_mypage_tag_path(tag)
+        expect(response).to redirect_to new_user_session_path
+      end
+    end
+  end
+
+  describe "PATCH /users/mypage/tags/:id #update" do
+    context 'ログインしている場合' do
+      before do
+        sign_in(tag.user)
+      end
+      context "更新が失敗する場合" do
+        it "無効な値だと更新されないこと" do
+          expect {patch users_mypage_tag_path(tag), params: {tag: {name: '',
+                                                                  user_id: ''}}
+          }.to_not change(Tag, :count)
+        end
+      end
+      context "更新成功する場合" do
+        let!(:tag_params) {{tag: {name: tag.name,
+                                  user_id: tag.user_id}}}
+        it "更新されること" do
+          expect{patch users_mypage_tag_path(tag), params: tag_params
+          }.to_not change(Tag, :count)
+          expect(tag.reload.name).to eq "MyString"
+        end
+        it "マイページにリダイレクトされること" do
+          patch users_mypage_tag_path(tag), params: tag_params
+          expect(response).to redirect_to users_mypage_path
+          expect(flash[:success]).to be_truthy
+        end
+      end
+    end
+    context "ログインしていない場合" do
+      it "ログインページにリダイレクトされること" do
+        patch users_mypage_tag_path(tag)
+        expect(response).to redirect_to new_user_session_path
+      end
+    end
+  end
+
+  describe "DELETE /users/mypage/tags/:id #delete" do
+    context "ログインしている場合" do
+      before do
+        sign_in(tag.user)
+      end
+
+      context "削除が成功する場合" do
+        it "タグが削除されること" do
+          expect{delete users_mypage_tag_path(tag)
+          }.to change(Tag, :count).by(-1)
+        end
+        it "マイページにリダイレクトされること" do
+          delete users_mypage_tag_path(tag)
+          expect(response).to redirect_to users_mypage_path
+          expect(flash[:success]).to be_truthy
+        end
+      end
+    end
+    context "ログインしていない場合" do
+      it "ログインページにリダイレクトされること" do
+        delete users_mypage_tag_path(tag)
+        expect(response).to redirect_to new_user_session_path
+      end
+    end
+  end
 end


### PR DESCRIPTION
why
現状タグを登録することしかできないため。

what
編集機能、削除機能を追加する

タグの詳細ページから編集ページに飛べるようにする
編集ページから更新、削除ができるようにする
更新のときは、タグは必須にする

![スクリーンショット 2022-07-11 11 18 54](https://user-images.githubusercontent.com/73515602/178176580-2fc7187d-16fe-4cc4-989c-2c7c5b0eb811.png)

