### PR TITLE
[update]#43 終了期日は過去の日付を登録できないようにする

### DIFF
--- a/app/controllers/users/todos_controller.rb
+++ b/app/controllers/users/todos_controller.rb
@@ -1,6 +1,6 @@
 module Users
   class TodosController < UsersController
-    before_action :find_todo_detail, only: [:edit, :destroy] #update
+    before_action :find_todo_detail, only: [:edit, :update, :destroy]
     before_action :todo_params_for_update, only: :update
 
     def new
@@ -9,15 +9,12 @@ module Users
 
     def create
       @todo = current_user.todos.new(todo_params)
-      if tag_todo_valid_for_create?(new_tag, @todo)
-        p @todo.errors.full_messages
+      if tag_todo_valid?(new_tag, @todo)
         @todo.save
         @todo.save_tag(new_tag, checkbox_tag)
         flash[:success] = "登録が成功しました！"
         redirect_to users_mypage_path
       else
-        puts '-----------create_else---------------'
-        p @todo.errors.full_messages
         @tags = params[:todo][:name]
         render 'new', status: :unprocessable_entity
       end
@@ -28,16 +25,12 @@ module Users
     end
 
     def update
-      todo_params_for_update
       if tag_todo_valid?(new_tag, @todo)
-        p @todo.errors.full_messages
         @todo.save
         @todo.save_tag(new_tag, checkbox_tag)
         flash[:success] = "Todoを更新しました！"
         redirect_to users_mypage_path
       else
-        puts '-----------update_else---------------'
-        p @todo.errors
         @tags = params[:todo][:name]
         @comment = Comment.new(todo_id: @todo.id, user_id: current_user.id)
         render 'edit', status: :unprocessable_entity
@@ -76,39 +69,16 @@ module Users
       params[:todo][:tag_ids].reject(&:empty?)
     end
 
-    def tag_todo_valid_for_create?(tag_names, todo)
+    def tag_todo_valid?(tag_names, todo)
+      # tag1つずつに対してバリデーションをかける、重複は省く
       valid_each_tag(tag_names)
-      todo.valid?(:changed)
+
+      todo.valid?
       @tags_errors.empty? && todo.errors.empty?
     end
 
-    def tag_todo_valid?(tag_names, todo)
-      # tag1つずつに対してバリデーションをかける、重複は省く
-      @tags_errors = tag_names.map do |tag|
-        tag = Tag.new(name: tag, user_id: current_user.id)
-        tag.valid?
-        tag.errors.full_messages
-      end.flatten.uniq
-
-      if no_change_limit_date?
-        puts '--------no_change--------------------'
-        p todo.valid?
-        p todo.errors
-        todo.valid?
-        @tags_errors.empty? && todo.errors.empty?
-      else
-        # 終了期日に変化があればpretend_agoのバリデーションをかける
-        puts '--------changed--------------------'
-        p todo.valid?(:changed)
-        p todo.errors
-        todo.valid?(:changed) # 過去の日付ならfalseになる
-        @tags_errors.empty? && todo.errors.empty?
-      end
-    end
-
     def todo_params_for_update
-      @todo = current_user.todos.find(params[:id])
-      # @todo = Todo.find(params[:id])
+      @todo = Todo.find(params[:id])
       @todo.title = todo_params[:title]
       @todo.text = todo_params[:text]
       @todo.limit_date = todo_params[:limit_date]
@@ -130,12 +100,6 @@ module Users
         tag.valid?
         tag.errors.full_messages
       end.flatten.uniq
-    end
-
-    def no_change_limit_date?
-      before = find_todo_detail
-      todo_params_for_update
-      before.limit_date == @todo.limit_date
     end
   end
 end

--- a/app/models/todo.rb
+++ b/app/models/todo.rb
@@ -4,10 +4,7 @@ class Todo < ApplicationRecord
   validates :limit_date, presence: true
   validates :status, presence: true
   validate :file_length
-
-  with_options on: :changed do
-    validate :pretend_ago
-  end
+  validate :pretend_ago
 
   has_many_attached :images do |attachable|
     attachable.variant :thumb, resize_to_limit: [100, 100]
@@ -77,6 +74,8 @@ class Todo < ApplicationRecord
   end
 
   def pretend_ago
-    errors.add(:limit_date, 'は先の日付にしてください' ) if limit_date.nil? || limit_date < Date.today
+    return if status == '完了' || status == '期限切れ'
+
+    errors.add(:limit_date, 'は先の日付にしてください') if limit_date.nil? || limit_date < Date.today # or Time.current.yesterday
   end
 end

--- a/app/models/todo.rb
+++ b/app/models/todo.rb
@@ -4,6 +4,11 @@ class Todo < ApplicationRecord
   validates :limit_date, presence: true
   validates :status, presence: true
   validate :file_length
+
+  with_options on: :changed do
+    validate :pretend_ago
+  end
+
   has_many_attached :images do |attachable|
     attachable.variant :thumb, resize_to_limit: [100, 100]
   end
@@ -69,5 +74,9 @@ class Todo < ApplicationRecord
 
   def file_length
     return errors.add(:images, 'は3ファイルまでにしてください') if images.length > 3
+  end
+
+  def pretend_ago
+    errors.add(:limit_date, 'は先の日付にしてください' ) if limit_date.nil? || limit_date < Date.today
   end
 end

--- a/app/models/todo.rb
+++ b/app/models/todo.rb
@@ -76,6 +76,6 @@ class Todo < ApplicationRecord
   def pretend_ago
     return if status == '完了' || status == '期限切れ'
 
-    errors.add(:limit_date, 'は先の日付にしてください') if limit_date.nil? || limit_date < Date.today # or Time.current.yesterday
+    errors.add(:limit_date, 'は先の日付にしてください') if limit_date.nil? || limit_date < Time.current.yesterday
   end
 end

--- a/app/views/users/todos/_form.html.slim
+++ b/app/views/users/todos/_form.html.slim
@@ -4,7 +4,6 @@
 
   = form_with model: [:users, @todo ],local: true do |f|
     ul
-      = @todo.errors.full_messages
       - @todo.errors.full_messages.each do |message|
         li.error-messages= message
     ul
@@ -25,7 +24,10 @@
     = f.label '終了期日'
     = f.date_field :limit_date
     = f.label 'ステータス'
-    = f.select :status, options_for_select([["未完了","todo"], ["完了","done"]])
+    - if @todo.user
+      = f.select :status, ([["未完了","todo"], ["完了","done"]])
+    - else
+      = f.select :status, options_for_select([["未完了","todo"]])
     = f.label :images
     = f.file_field :images, multiple: true
     - @todo.errors.full_messages_for(:images).each do |message|

--- a/app/views/users/todos/_form.html.slim
+++ b/app/views/users/todos/_form.html.slim
@@ -4,6 +4,7 @@
 
   = form_with model: [:users, @todo ],local: true do |f|
     ul
+      = @todo.errors.full_messages
       - @todo.errors.full_messages.each do |message|
         li.error-messages= message
     ul

--- a/spec/factories/todos.rb
+++ b/spec/factories/todos.rb
@@ -3,7 +3,6 @@ FactoryBot.define do
     title { "MyString" }
     text { "MyText" }
     limit_date {Time.current}
-    # "Sun, 05 Jun 2022"
     status {"todo"}
     user
     # association :user
@@ -13,11 +12,18 @@ FactoryBot.define do
     #   post.image.attach(io: File.open('spec/fixtures/files/image/test_image.png'), filename: 'test_image.png', content_type: 'image/png')
     # end
 
+    trait :todo_change_status do
+      limit_date {Time.current.yesterday}
+    end
+
+    trait :skip_validate do
+      to_create {|instance| instance.save(validate: false)}
+    end
+
     trait :with_attachment do
       attachment { Rack::Test::UploadedFile.new(
       "#{Rails.root}/spec/fixtures/files/image/test_image.png", 'image/png') }
     end
 
   end
-
 end

--- a/spec/models/todo_spec.rb
+++ b/spec/models/todo_spec.rb
@@ -112,13 +112,8 @@ RSpec.describe Todo, type: :model do
   describe 'change_statusメソッド' do
     let!(:user) { create(:user) }
     context 'after_commitが実行される' do
-      # puts '---------------------'
-      # puts '---------------------'
-      # p Todo.last
-      # let!(:todo) { create(:todo, limit_date: Time.current.yesterday)}
       it '未完了から期限切れになること' do
-        # expect{Todo.change_status}.to change{ todo.reload.status }.from('未完了').to('期限切れ')
-        expect{Todo.change_status}.to change{ todo.status }.from('未完了').to('期限切れ')
+        expect{Todo.change_status}.to change{ Todo.find(14351).status }.from('未完了').to('期限切れ')
       end
     end
   end

--- a/spec/models/todo_spec.rb
+++ b/spec/models/todo_spec.rb
@@ -112,9 +112,13 @@ RSpec.describe Todo, type: :model do
   describe 'change_statusメソッド' do
     let!(:user) { create(:user) }
     context 'after_commitが実行される' do
-      let!(:todo) { create(:todo, limit_date: Time.current.yesterday)}
+      # puts '---------------------'
+      # puts '---------------------'
+      # p Todo.last
+      # let!(:todo) { create(:todo, limit_date: Time.current.yesterday)}
       it '未完了から期限切れになること' do
-        expect{Todo.change_status}.to change{ todo.reload.status }.from('未完了').to('期限切れ')
+        # expect{Todo.change_status}.to change{ todo.reload.status }.from('未完了').to('期限切れ')
+        expect{Todo.change_status}.to change{ todo.status }.from('未完了').to('期限切れ')
       end
     end
   end

--- a/spec/models/todo_spec.rb
+++ b/spec/models/todo_spec.rb
@@ -111,9 +111,11 @@ RSpec.describe Todo, type: :model do
 
   describe 'change_statusメソッド' do
     let!(:user) { create(:user) }
+    let!(:todo) { create(:todo, :todo_change_status, :skip_validate) }
+
     context 'after_commitが実行される' do
       it '未完了から期限切れになること' do
-        expect{Todo.change_status}.to change{ Todo.find(14351).status }.from('未完了').to('期限切れ')
+        expect{Todo.change_status}.to change{ todo.reload.status }.from('未完了').to('期限切れ')
       end
     end
   end


### PR DESCRIPTION
# Why
現状どの日付でも登録できてしまうため

# What
新規登録 → 過去の日付は登録できないようにする

更新→ 期日の入力に変化があれば → 過去の日付は登録できないようにする