### PR TITLE
[update]#44 バッチ処理 スラックへの通知を1回のみにする

### DIFF
--- a/lib/tasks/change_status.rake
+++ b/lib/tasks/change_status.rake
@@ -9,8 +9,8 @@ namespace :change_status do
   rescue StandardError => e
     if num_attempts <= MAX_ATTEMPTS
       sleep 60
-      message = p "期限切れのTodoステータス変更エラーが発生しました!(#{num_attempts}回目目)"
-      Todo.send_error_message(message)
+      message = p "期限切れのTodoステータス変更が失敗しました!(#{num_attempts}回目目)"
+      Todo.send_error_message(message) if num_attempts == MAX_ATTEMPTS
       retry
     else
       puts e

--- a/lib/tasks/change_status.rake
+++ b/lib/tasks/change_status.rake
@@ -7,14 +7,14 @@ namespace :change_status do
     num_attempts += 1
     Todo.change_status
   rescue StandardError => e
-    if num_attempts <= MAX_ATTEMPTS
-      sleep 60
-      message = p "期限切れのTodoステータス変更が失敗しました!(#{num_attempts}回目目)"
-      Todo.send_error_message(message) if num_attempts == MAX_ATTEMPTS
+    if num_attempts < MAX_ATTEMPTS
+      sleep 3
       retry
     else
       puts e
     end
+    message = p "期限切れのTodoステータス変更が失敗しました!(#{num_attempts}回目目)"
+    Todo.send_error_message(message)
   ensure
     puts 'finish!!!!!!!!!!!!!!!!!!!!!'
   end

--- a/lib/tasks/change_status.rake
+++ b/lib/tasks/change_status.rake
@@ -8,14 +8,12 @@ namespace :change_status do
     Todo.change_status
   rescue StandardError => e
     if num_attempts < MAX_ATTEMPTS
-      sleep 3
+      sleep 60
       retry
     else
       puts e
     end
-    message = p "期限切れのTodoステータス変更が失敗しました!(#{num_attempts}回目目)"
+    message = "期限切れのTodoステータス変更が失敗しました!(#{num_attempts}回目目)"
     Todo.send_error_message(message)
-  ensure
-    puts 'finish!!!!!!!!!!!!!!!!!!!!!'
   end
 end

--- a/lib/tasks/todo_notifier.rake
+++ b/lib/tasks/todo_notifier.rake
@@ -8,14 +8,12 @@ namespace :todo_notifier do
     Todo.notice_expired_todo
   rescue StandardError => e
     if num_attempts < MAX_ATTEMPTS
-      sleep 3
+      sleep 60
       retry
     else
       puts e
     end
-    message = p "1日後に終了期限のTodo取得が失敗しました!(#{num_attempts}回目目)"
+    message = "1日後に終了期限のTodo取得が失敗しました!(#{num_attempts}回目目)"
     Todo.send_error_message(message)
-  ensure
-    puts 'finish!!!!!!!!!!!!!!!!!!!!!'
   end
 end

--- a/lib/tasks/todo_notifier.rake
+++ b/lib/tasks/todo_notifier.rake
@@ -9,8 +9,8 @@ namespace :todo_notifier do
   rescue StandardError => e
     if num_attempts <= MAX_ATTEMPTS
       sleep 60
-      message = p "1日後に終了期限のTodo取得のエラーが発生しました!(#{num_attempts}回目目)"
-      Todo.send_error_message(message)
+      message = p "1日後に終了期限のTodo取得が失敗しました!(#{num_attempts}回目目)"
+      Todo.send_error_message(message) if num_attempts == MAX_ATTEMPTS
       retry
     else
       puts e

--- a/lib/tasks/todo_notifier.rake
+++ b/lib/tasks/todo_notifier.rake
@@ -7,14 +7,14 @@ namespace :todo_notifier do
     num_attempts += 1
     Todo.notice_expired_todo
   rescue StandardError => e
-    if num_attempts <= MAX_ATTEMPTS
-      sleep 60
-      message = p "1日後に終了期限のTodo取得が失敗しました!(#{num_attempts}回目目)"
-      Todo.send_error_message(message) if num_attempts == MAX_ATTEMPTS
+    if num_attempts < MAX_ATTEMPTS
+      sleep 3
       retry
     else
       puts e
     end
+    message = p "1日後に終了期限のTodo取得が失敗しました!(#{num_attempts}回目目)"
+    Todo.send_error_message(message)
   ensure
     puts 'finish!!!!!!!!!!!!!!!!!!!!!'
   end


### PR DESCRIPTION
 # why
例外が発生した際に、スラックへの通知は3回送る必要がないため

 # What
スラックへの通知は1度のみし、失敗した結果のみを通知する