### PR TITLE
[update]#41 画像を表示させる ＆ 画像の追加と削除が同時にできるようにする

### DIFF
--- a/app/controllers/users/todos_controller.rb
+++ b/app/controllers/users/todos_controller.rb
@@ -9,7 +9,7 @@ module Users
 
     def create
       @todo = current_user.todos.new(todo_params)
-      if tag_todo_valid?(new_tag, @todo)
+      if tag_todo_img_valid?(new_tag, @todo)
         @todo.save
         @todo.save_tag(new_tag, checkbox_tag)
         flash[:success] = "登録が成功しました！"
@@ -25,7 +25,7 @@ module Users
     end
 
     def update
-      if tag_todo_valid?(new_tag, @todo)
+      if tag_todo_img_valid?(new_tag, @todo)
         @todo.save(context: :to_delete_images)
         @todo.save_tag(new_tag, checkbox_tag)
         flash[:success] = "Todoを更新しました！"
@@ -34,7 +34,6 @@ module Users
       else
         @tags = params[:todo][:name]
         @comment = Comment.new(todo_id: @todo.id, user_id: current_user.id)
-        flash[:notice] = "更新に失敗しました。"
         render 'edit', status: :unprocessable_entity
       end
     end
@@ -66,28 +65,26 @@ module Users
       params[:todo][:tag_ids].reject(&:empty?)
     end
 
-    def tag_todo_valid?(tag_names, todo)
+    def tag_todo_img_valid?(tag_names, todo)
       # tag1つずつに対してバリデーションをかける、重複は省く
       @tags_errors = tag_names.map do |tag|
         tag = Tag.new(name: tag, user_id: current_user.id)
         tag.valid?
         tag.errors.full_messages
       end.flatten.uniq
-
       return unless todo.valid?(:to_delete_images) && image_valid?
 
       @tags_errors.empty? && todo.errors.empty?
     end
 
     def image_valid?
+      @image_error = '3枚以上画像は登録できません'
       # 既存の数 - 削除数  = 残った数
-      left_images_ids = params[:all_image_ids].to_a.count - params[:todo][:image_ids].to_a.count
+      left_images_ids = @todo.images.count - params[:todo][:image_ids].to_a.count
+      # add_images = params.dig(:todo, :images) ? params.dig(:todo, :images).count : 0
+      add_images = params[:todo][:images] ? params[:todo][:images].count : 0
       # 残った数 + 追加数 = 合計数
-      if params[:todo][:images]
-        new_and_old_images_ids = left_images_ids + params[:todo][:images].to_a.count
-      else
-        new_and_old_images_ids = left_images_ids + 0
-      end
+      new_and_old_images_ids = left_images_ids + add_images
       new_and_old_images_ids <= 3
     end
 

--- a/app/controllers/users/todos_controller.rb
+++ b/app/controllers/users/todos_controller.rb
@@ -24,95 +24,20 @@ module Users
       @comment = Comment.new(todo_id: @todo.id, user_id: current_user.id)
     end
 
-# 1---------------------------------------------------------------------------------------------
-  #1 今ある画像（最大３枚）から削除する画像を引いて残りの画像を出す
-  #2 残った数と追加される数を足して合計を出す
-  #3 合計の数が３以下なら
-  #4 tag_todo.valid
-
-def update
-  # 既存の数 - 削除数  = 残った数
-  left_images_ids = params[:all_image_ids].to_a.count - params[:todo][:image_ids].to_a.count
-  # 残った数 + 追加数 = 合計数
-  new_and_old_images_ids = left_images_ids + params[:todo][:images].to_a.count
-
-  if new_and_old_images_ids <= 3
-    if tag_todo_valid?(new_tag, @todo)
-      @todo.save(context: :to_delete_images)
-      @todo.save_tag(new_tag, checkbox_tag)
-      flash[:success] = "Todoを更新しました！"
-      redirect_to users_mypage_path
-      delete_images if params[:todo][:image_ids]
-    else
-      @tags = params[:todo][:name]
-      @comment = Comment.new(todo_id: @todo.id, user_id: current_user.id)
-      flash[:notice] = "更新に失敗しました。"
-      render 'edit', status: :unprocessable_entity
+    def update
+      if tag_todo_valid?(new_tag, @todo)
+        @todo.save(context: :to_delete_images)
+        @todo.save_tag(new_tag, checkbox_tag)
+        flash[:success] = "Todoを更新しました！"
+        redirect_to users_mypage_path
+        delete_images if params[:todo][:image_ids]
+      else
+        @tags = params[:todo][:name]
+        @comment = Comment.new(todo_id: @todo.id, user_id: current_user.id)
+        flash[:notice] = "更新に失敗しました。"
+        render 'edit', status: :unprocessable_entity
+      end
     end
-  else
-    @tags = params[:todo][:name]
-    @comment = Comment.new(todo_id: @todo.id, user_id: current_user.id)
-    flash[:notice] = "更新に失敗しました。"
-    render 'edit', status: :unprocessable_entity
-  end
-end
-# 1---------------------------------------------------------------------------------------------
-
-
-# 2---------------------------------------------------------------------------------------------
-    #1 画像削除 (@todo.images.count の数が減ること)
-    #2  @todo.images.count + params[:todo][:images].to_a.count(追加する画像の数) が３以下なら
-    #3 tag_todo_valid
-
-def update
-  if params[:todo][:image_ids]
-    puts '------------1-------------'
-    p @todo.images.length
-    delete_images
-    @todo.images.reload
-    puts '------------2-------------'
-    p @todo.images.length
-    # @todo.save
-  end
-  puts '------------3-------------'
-  p @todo.images.length
-  p @todo.images.count + params[:todo][:images].to_a.count
-  p params[:todo][:images].to_a.count
-  p @todo.images.count
-
-  if @todo.images.count + params[:todo][:images].to_a.count <= 3
-    if tag_todo_valid?(new_tag, @todo)
-      @todo.save
-      @todo.save_tag(new_tag, checkbox_tag)
-      flash[:success] = "Todoを更新しました！"
-      redirect_to users_mypage_path
-    else
-      puts '-----------g--------------'
-      @tags = params[:todo][:name]
-      @comment = Comment.new(todo_id: @todo.id, user_id: current_user.id)
-      render 'edit', status: :unprocessable_entity
-    end
-  else
-    @tags = params[:todo][:name]
-    @comment = Comment.new(todo_id: @todo.id, user_id: current_user.id)
-    ender 'edit', status: :unprocessable_entity
-  end
-end
-# 2---------------------------------------------------------------------------------------------
-
-    # def update
-    #   if tag_todo_valid?(new_tag, @todo)
-    #     @todo.save
-    #     @todo.save_tag(new_tag, checkbox_tag)
-    #     flash[:success] = "Todoを更新しました！"
-    #     redirect_to users_mypage_path
-    #     delete_images
-    #   else
-    #     @tags = params[:todo][:name]
-    #     @comment = Comment.new(todo_id: @todo.id, user_id: current_user.id)
-    #     render 'edit', status: :unprocessable_entity
-    #   end
-    # end
 
     def destroy
       @todo.destroy
@@ -148,20 +73,23 @@ end
         tag.valid?
         tag.errors.full_messages
       end.flatten.uniq
-      return unless todo.valid?(:to_delete_images) #画像のバリデーション無視
+
+      return unless todo.valid?(:to_delete_images) && image_valid?
+
       @tags_errors.empty? && todo.errors.empty?
     end
 
-    # def tag_todo_valid2?(tag_names, todo)
-    #   # tag1つずつに対してバリデーションをかける、重複は省く
-    #   @tags_errors = tag_names.map do |tag|
-    #     tag = Tag.new(name: tag, user_id: current_user.id)
-    #     tag.valid?
-    #     tag.errors.full_messages
-    #   end.flatten.uniq
-    #   todo.valid?
-    #   @tags_errors.empty? && todo.errors.empty?
-    # end
+    def image_valid?
+      # 既存の数 - 削除数  = 残った数
+      left_images_ids = params[:all_image_ids].to_a.count - params[:todo][:image_ids].to_a.count
+      # 残った数 + 追加数 = 合計数
+      if params[:todo][:images]
+        new_and_old_images_ids = left_images_ids + params[:todo][:images].to_a.count
+      else
+        new_and_old_images_ids = left_images_ids + 0
+      end
+      new_and_old_images_ids <= 3
+    end
 
     def todo_params_for_update
       @todo = Todo.find(params[:id])

--- a/app/controllers/users/todos_controller.rb
+++ b/app/controllers/users/todos_controller.rb
@@ -80,7 +80,7 @@ module Users
     def image_valid?
       # 全体（既存数＋追加数） - 削除数 - 追加数  = 残った数
       left_images_ids = @todo.images.count - params.dig(:todo, :image_ids).to_a.count - params[:todo][:images].to_a.count
-      add_images = params.dig(:todo, :images) ? params.dig(:todo, :images)&.count : 0
+      add_images = params.dig(:todo, :images) ? params.dig(:todo, :images).count : 0
       # 残った数 + 追加数 = 合計数
       new_and_old_images_ids = left_images_ids + add_images
       if new_and_old_images_ids <= 3

--- a/app/controllers/users/todos_controller.rb
+++ b/app/controllers/users/todos_controller.rb
@@ -78,13 +78,17 @@ module Users
     end
 
     def image_valid?
-      @image_error = '3枚以上画像は登録できません'
-      # 既存の数 - 削除数  = 残った数
-      left_images_ids = @todo.images.count - params.dig(:todo, :image_ids).to_a.count
+      # 全体（既存数＋追加数） - 削除数 - 追加数  = 残った数
+      left_images_ids = @todo.images.count - params.dig(:todo, :image_ids).to_a.count - params[:todo][:images].to_a.count
       add_images = params.dig(:todo, :images) ? params.dig(:todo, :images)&.count : 0
       # 残った数 + 追加数 = 合計数
       new_and_old_images_ids = left_images_ids + add_images
-      new_and_old_images_ids <= 3
+      if new_and_old_images_ids <= 3
+        true
+      else
+        @image_error = '3枚以上画像は登録できません'
+        false
+      end
     end
 
     def todo_params_for_update

--- a/app/controllers/users/todos_controller.rb
+++ b/app/controllers/users/todos_controller.rb
@@ -10,7 +10,7 @@ module Users
     def create
       @todo = current_user.todos.new(todo_params)
       if tag_todo_img_valid?(new_tag, @todo)
-        @todo.save
+        @todo.save(context: :to_delete_images)
         @todo.save_tag(new_tag, checkbox_tag)
         flash[:success] = "登録が成功しました！"
         redirect_to users_mypage_path
@@ -80,9 +80,8 @@ module Users
     def image_valid?
       @image_error = '3枚以上画像は登録できません'
       # 既存の数 - 削除数  = 残った数
-      left_images_ids = @todo.images.count - params[:todo][:image_ids].to_a.count
-      # add_images = params.dig(:todo, :images) ? params.dig(:todo, :images).count : 0
-      add_images = params[:todo][:images] ? params[:todo][:images].count : 0
+      left_images_ids = @todo.images.count - params.dig(:todo, :image_ids).to_a.count
+      add_images = params.dig(:todo, :images) ? params.dig(:todo, :images)&.count : 0
       # 残った数 + 追加数 = 合計数
       new_and_old_images_ids = left_images_ids + add_images
       new_and_old_images_ids <= 3

--- a/app/controllers/users/todos_controller.rb
+++ b/app/controllers/users/todos_controller.rb
@@ -30,16 +30,17 @@ module Users
         @todo.save_tag(new_tag, checkbox_tag)
         flash[:success] = "Todoを更新しました！"
         redirect_to users_mypage_path
+        delete_images
       else
         @tags = params[:todo][:name]
         @comment = Comment.new(todo_id: @todo.id, user_id: current_user.id)
         render 'edit', status: :unprocessable_entity
       end
 
-      # 削除する画像がある場合（check boxにチェックがない場合はparamsにimage_idsはない）
-      return unless params[:todo][:image_ids]
+      # # 削除する画像がある場合（check boxにチェックがない場合はparamsにimage_idsはない）
+      # return unless params[:todo][:image_ids]
 
-      delete_images
+      # delete_images
     end
 
     def destroy
@@ -77,7 +78,7 @@ module Users
         tag.errors.full_messages
       end.flatten.uniq
 
-      todo.valid?
+      todo.valid?(:to_delete_images)
       @tags_errors.empty? && todo.errors.empty?
     end
 
@@ -90,11 +91,22 @@ module Users
       @todo.images = todo_params[:images]
     end
 
+    # def delete_images
+    #   params[:todo][:image_ids].each do |image_id|
+    #     image = @todo.images.find(image_id)
+    #     image.purge
+    #   end
+    # end
+
     def delete_images
+      return unless params[:todo][:image_ids]
+
+      @todo.save(context: :to_delete_images)
       params[:todo][:image_ids].each do |image_id|
-        image = @todo.images.find(image_id)
-        image.purge
+        @todo.images.find(image_id).purge
       end
+      @todo.images.reload
+      @todo.save
     end
   end
 end

--- a/app/controllers/users/todos_controller.rb
+++ b/app/controllers/users/todos_controller.rb
@@ -98,8 +98,6 @@ module Users
     end
 
     def delete_images
-      return unless params[:todo][:image_ids]
-
       params[:todo][:image_ids].each do |image_id|
         image = ActiveStorage::Attachment.find(image_id)
         image.purge

--- a/app/controllers/users/todos_controller.rb
+++ b/app/controllers/users/todos_controller.rb
@@ -79,11 +79,8 @@ module Users
 
     def image_valid?
       # 全体（既存数＋追加数） - 削除数 - 追加数  = 残った数
-      left_images_ids = @todo.images.count - params.dig(:todo, :image_ids).to_a.count - params[:todo][:images].to_a.count
-      add_images = params.dig(:todo, :images) ? params.dig(:todo, :images).count : 0
-      # 残った数 + 追加数 = 合計数
-      new_and_old_images_ids = left_images_ids + add_images
-      if new_and_old_images_ids <= 3
+      left_images = @todo.images.count - params.dig(:todo, :image_ids).to_a.count
+      if left_images <= 3
         true
       else
         @image_error = '3枚以上画像は登録できません'

--- a/app/models/todo.rb
+++ b/app/models/todo.rb
@@ -3,7 +3,8 @@ class Todo < ApplicationRecord
   validates :text, presence: true, length: { maximum: 140 }
   validates :limit_date, presence: true
   validates :status, presence: true
-  validate :file_length
+  validate :file_length, unless: -> { validation_context == :to_delete_images }
+  # validate :file_length
   has_many_attached :images do |attachable|
     attachable.variant :thumb, resize_to_limit: [100, 100]
   end

--- a/app/models/todo.rb
+++ b/app/models/todo.rb
@@ -4,7 +4,7 @@ class Todo < ApplicationRecord
   validates :limit_date, presence: true
   validates :status, presence: true
   validate :file_length, unless: -> { validation_context == :to_delete_images }
-  # validate :file_length
+
   has_many_attached :images do |attachable|
     attachable.variant :thumb, resize_to_limit: [100, 100]
   end

--- a/app/views/users/todos/_form.html.slim
+++ b/app/views/users/todos/_form.html.slim
@@ -31,6 +31,9 @@
     - if @todo.images.attached?
       p 削除するものはチェックして下さい
       - @todo.images.each do |image|
+        = hidden_field_tag 'all_image_ids[]', image.id
+        / = f.hidden_field :left_image_ids, value: image.id
+        = image.id
         = f.check_box :image_ids, {multiple: true}, image.id, false
         li.user= image_tag image.variant(:thumb)
     = f.submit class: "btn btn-primary"

--- a/app/views/users/todos/_form.html.slim
+++ b/app/views/users/todos/_form.html.slim
@@ -10,6 +10,9 @@
       - if @tags_errors.present?
         - @tags_errors.each do |message|
           li.error-messages= message
+    ul
+      - if @todo.images.count > 3
+        li.error-messages= @image_error
 
     = f.label :title
     = f.text_field :title
@@ -31,7 +34,6 @@
     - if @todo.images.attached?
       p 削除するものはチェックして下さい
       - @todo.images.each do |image|
-        = hidden_field_tag 'all_image_ids[]', image.id
         = f.check_box :image_ids, {multiple: true}, image.id, false
         li.user= image_tag image.variant(:thumb)
     = f.submit class: "btn btn-primary"

--- a/app/views/users/todos/_form.html.slim
+++ b/app/views/users/todos/_form.html.slim
@@ -20,15 +20,14 @@
     = f.label '既存のタグ一覧'
     .tag_checkbox
       .tags
-        = f.collection_check_boxes(:tag_ids, @todo.tags, :id, :name)
+        = f.collection_check_boxes(:tag_ids, @todo.tags, :id, :name, include_hidden: false)
     = f.label '終了期日'
     = f.date_field :limit_date
     = f.label 'ステータス'
     = f.select :status, options_for_select([["未完了","todo"], ["完了","done"]])
-    = f.label :images
-    = f.file_field :images, multiple: true
-    - @todo.errors.full_messages_for(:images).each do |message|
-      = message
+    = f.label '画像（3枚まで）'
+    = f.file_field :images, multiple: true, include_hidden: false
+
     - if @todo.images.attached?
       p 削除するものはチェックして下さい
       - @todo.images.each do |image|

--- a/app/views/users/todos/_form.html.slim
+++ b/app/views/users/todos/_form.html.slim
@@ -32,8 +32,6 @@
       p 削除するものはチェックして下さい
       - @todo.images.each do |image|
         = hidden_field_tag 'all_image_ids[]', image.id
-        / = f.hidden_field :left_image_ids, value: image.id
-        = image.id
         = f.check_box :image_ids, {multiple: true}, image.id, false
         li.user= image_tag image.variant(:thumb)
     = f.submit class: "btn btn-primary"

--- a/app/views/users/todos/_form.html.slim
+++ b/app/views/users/todos/_form.html.slim
@@ -33,9 +33,10 @@
 
     - if @todo.images.attached?
       p 削除するものはチェックして下さい
-      - @todo.images.each do |image|
+      - @todo.images.each_with_index do |image, i|
         = f.check_box :image_ids, {multiple: true}, image.id, false
         li.user= image_tag image.variant(:thumb)
+        - break if i == 2
     = f.submit class: "btn btn-primary"
 
   = link_to '戻る', users_mypage_path

--- a/app/views/users/todos/_form.html.slim
+++ b/app/views/users/todos/_form.html.slim
@@ -11,7 +11,7 @@
         - @tags_errors.each do |message|
           li.error-messages= message
     ul
-      - if @todo.images.count > 3
+      - if @image_error.present?
         li.error-messages= @image_error
 
     = f.label :title

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,6 +29,7 @@ Rails.application.routes.draw do
   end
 
   root 'general#index'
-  get '*not_found' => 'application#routing_error'
-  post '*not_found' => 'application#routing_error'
+  # 画像がリンク切れになっているため一旦コメントアウト
+  # get '*not_found' => 'application#routing_error'
+  # post '*not_found' => 'application#routing_error'
 end

--- a/spec/requests/user/todos_spec.rb
+++ b/spec/requests/user/todos_spec.rb
@@ -169,10 +169,11 @@ RSpec.describe "Todos", type: :request do
                                                               title: todo.title,
                                                               text: todo.text,
                                                               image_ids: [todo.images[0].id],
+                                                              images: todo.images,
                                                               name: tag.name,
                                                               tag_ids: [tag.id]
                                                             }}
-            }.to change { todo.images.count }.from(1).to(0)
+            }.to_not change {todo.images.count}
           end
         end
       end

--- a/spec/requests/user/todos_spec.rb
+++ b/spec/requests/user/todos_spec.rb
@@ -66,14 +66,15 @@ RSpec.describe "Todos", type: :request do
           end
           it '登録されること(画像あり)' do
             expect{
-              post users_todos_path(todo), params: { todo: {
+              post users_todos_path(todo_params), params: { todo: {
                                                         title: todo.title,
                                                         text: todo.text,
                                                         user_id: todo.user.id ,
                                                         images: todo.images,
                                                         name: tag.name,
                                                         tag_ids: [],
-                                                        limit_date: Time.current
+                                                        limit_date: Time.current,
+                                                        status: todo.status
                                                     } }
               }.to change(Todo, :count).by 1
           end


### PR DESCRIPTION
# why
画像がリンク切れになっているため

![スクリーンショット 2022-07-11 6 47 59](https://user-images.githubusercontent.com/73515602/178163222-60409eca-1633-48d4-9d8a-341578a6dc18.png)


画像の追加と削除が同時にできるようにする

# what
エラーページのroutesを一旦コメントアウトにする

画像の保存→選択された画像を削除する流れ
validate :file_length, unless: -> { validation_context == :to_delete_images }を設定
